### PR TITLE
Enable replication

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -2,7 +2,7 @@
 
 # サイトをインターネットに公開する際のドメイン。
 # 親ドメインから本システムのDNSサーバにサブドメイン委任されていなければならない。
-domain: "{{ hive_name }}.local"
+domain: "{{ hive_name }}.{{ 'local' if hive_stage == 'production' else 'procube-demo.jp' }}"
 # 委任先の FQDN は ns[0-2]-{{ domain }} とする（グルーレコードではなく親ドメインの直下レコードとする）
 
 # パスワード最低文字数

--- a/roles/addon2/tasks/main.yml
+++ b/roles/addon2/tasks/main.yml
@@ -5,3 +5,9 @@
 - import_role:
     name: pull-docker-images
   when: inventory_hostname in groups['hives']
+# - import_role:
+#     name: enable-replication
+#   when: inventory_hostname in groups['repository']
+# - import_role:
+#     name: disable-replication
+#   when: inventory_hostname in groups['repository']

--- a/roles/disable-replication/tasks/main.yml
+++ b/roles/disable-replication/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- import_role:
+    name: backup-tools
+- name: disable start-replication timer
+  become: true
+  service:
+    daemon_reload: true
+    name: "start-replication.timer"
+    state: stopped

--- a/roles/disable-replication/tasks/main.yml
+++ b/roles/disable-replication/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
 - import_role:
     name: backup-tools
+- name: Check if Service Exists
+  shell: "if chkconfig --list | grep -q start-replication.timer;   then echo true;   else echo false; fi;"
+  register: service_exists
 - name: disable start-replication timer
   become: true
   service:
     daemon_reload: true
     name: "start-replication.timer"
     state: stopped
+  when: service_exists

--- a/roles/enable-replication/tasks/main.yml
+++ b/roles/enable-replication/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: stop backup timer
+  become: true
+  service:
+    daemon_reload: true
+    name: "backup.timer"
+    state: stopped
+- name: add replication service
+  become: True
+  template:
+    src: "{{item}}"
+    dest: /usr/lib/systemd/system
+    mode: 0644
+  with_items:
+    - start-replication.service
+    - start-replication.timer
+- name: enable and start replicaton timer service
+  become: True
+  service:
+    daemon_reload: True
+    name: "start-replication.timer"
+    enabled: True
+    state: started
+- name: add start-replication script
+  become: True
+  template:
+    src: start-replication.sh
+    dest: /usr/bin/start-replication.sh
+    mode: 0755

--- a/roles/enable-replication/templates/start-replication.service
+++ b/roles/enable-replication/templates/start-replication.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=database replication
+
+[Service]
+Type=oneshot
+WorkingDirectory={{ hive_home_dir }}
+ExecStart=/usr/bin/start-replication.sh
+User={{ hive_safe_admin }}
+Group={{ hive_safe_admin }}

--- a/roles/enable-replication/templates/start-replication.sh
+++ b/roles/enable-replication/templates/start-replication.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# scpでlatestのバックアップファイルを/home/admin/backup配下に置く
+
+for SERVICE in mongo idm
+do
+  hive-backup.sh -l $SERVICE -r
+done

--- a/roles/enable-replication/templates/start-replication.sh
+++ b/roles/enable-replication/templates/start-replication.sh
@@ -1,8 +1,12 @@
 #! /bin/bash
 
-# scpでlatestのバックアップファイルを/home/admin/backup配下に置く
+# scpでlatestのバックアップを/home/admin/backup配下に置く
+# for name in backup-idm-latest.tar.gz backup-idm_eu_app_csv-latest.tar.gz  backup-ldap-latest.ldif backup-ldap_config-latest.ldif backup-amdb-latest.sql.gz backup-guacamole_db-latest.sql.gz backup-mongo-backup-latest.tar.gz
+# do
+#   scp /home/admin/$name:/home/admin/$name
+# done
 
-for SERVICE in mongo idm
+for SERVICE in idm ldap amdb postgres mongo
 do
   hive-backup.sh -l $SERVICE -r
 done

--- a/roles/enable-replication/templates/start-replication.timer
+++ b/roles/enable-replication/templates/start-replication.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer for get backup files
+
+[Timer]
+OnCalendar=*-*-* 01:00:00
+Persistent=true
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
日次バッチでバックアップの採取とリストアを行います。
import_roleのサンプルはaddon2にコメントアウトして置いています。

enable-replicationをレポジトリサーバで動かすことでバックアップを取らなくなり、午前1時にstart-replication.shが動くようになります。
反対にdisable-replicationを動かすことでバックアップを取るようになり、start-replication.timerが止まります。